### PR TITLE
🎨 Switch to map() for navbar item generation

### DIFF
--- a/lib/models/pageOutline.dart
+++ b/lib/models/pageOutline.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 class PageOutline {
   final String pageName;
+  final String shortName;
   final IconData icon;
   final Widget body;
 
@@ -10,5 +11,6 @@ class PageOutline {
     @required this.pageName,
     @required this.icon,
     @required this.body,
+    this.shortName
   });
 }

--- a/lib/models/pageOutline.dart
+++ b/lib/models/pageOutline.dart
@@ -11,6 +11,6 @@ class PageOutline {
     @required this.pageName,
     @required this.icon,
     @required this.body,
-    this.shortName
+    this.shortName,
   });
 }

--- a/lib/routes/selector/pages/nfc_trade.dart
+++ b/lib/routes/selector/pages/nfc_trade.dart
@@ -10,6 +10,7 @@ import 'package:hack_club_gp/models/pageOutline.dart';
 class NFCTradePage {
   PageOutline get outline => PageOutline(
         pageName: 'NFC Trading',
+        shortName: 'NFC Trade',
         icon: MdiIcons.nfcTap,
         body: Container(),
       );

--- a/lib/routes/selector/pages/qr_trade.dart
+++ b/lib/routes/selector/pages/qr_trade.dart
@@ -10,6 +10,7 @@ import 'package:hack_club_gp/models/pageOutline.dart';
 class QRTradePage {
   PageOutline get outline => PageOutline(
         pageName: 'QR Code Trading',
+        shortName: 'QR Trade',
         icon: MdiIcons.qrcode,
         body: Container(),
       );

--- a/lib/routes/selector/selector.dart
+++ b/lib/routes/selector/selector.dart
@@ -66,24 +66,13 @@ class _SelectorRoute extends State<SelectorRoute> {
         selectedItemColor: Theme.of(context).scaffoldBackgroundColor,
         backgroundColor: Theme.of(context).appBarTheme.color,
         shadowColor: Colors.yellow,
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(MdiIcons.qrcode),
-            title: Text('QR Trade'),
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(MdiIcons.nfcTap),
-            title: Text('NFC Trade'),
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(MdiIcons.scaleBalance),
-            title: Text('Balance'),
-          ),
-        ],
-        padding: EdgeInsets.symmetric(
-          horizontal: 20,
-          vertical: 20,
-        ),
+        items: _pageOutlines.map((outline) {
+          return BottomNavigationBarItem(
+            icon: Icon(outline.icon),
+            title: Text(outline.shortName != null ? outline.shortName : outline.pageName),
+          );
+        }).toList(),
+        padding: EdgeInsets.all(20),
         showSelectedLabels: true,
         showUnselectedLabels: true,
         currentIndex: _currentIndex,

--- a/lib/routes/selector/selector.dart
+++ b/lib/routes/selector/selector.dart
@@ -69,7 +69,9 @@ class _SelectorRoute extends State<SelectorRoute> {
         items: _pageOutlines.map((outline) {
           return BottomNavigationBarItem(
             icon: Icon(outline.icon),
-            title: Text(outline.shortName != null ? outline.shortName : outline.pageName),
+            title: Text(outline.shortName != null
+                ? outline.shortName
+                : outline.pageName),
           );
         }).toList(),
         padding: EdgeInsets.all(20),


### PR DESCRIPTION
This adds a `shortName` field to the `PageOutline` class. The `shortName` is shown in the bottom navbar.

I also switched out `EdgeInsets.symmetric()` for `EdgeInsets.all()` (it's a bit shorter)